### PR TITLE
Implement centralized method from PR comment

### DIFF
--- a/src/api/providers/fetchers/deepinfra.ts
+++ b/src/api/providers/fetchers/deepinfra.ts
@@ -1,7 +1,7 @@
-import axios from "axios"
 import { z } from "zod"
 
 import { type ModelInfo } from "@roo-code/types"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 import { DEFAULT_HEADERS } from "../constants"
 
@@ -42,7 +42,8 @@ export async function getDeepInfraModels(
 	const url = `${baseUrl.replace(/\/$/, "")}/models`
 	const models: Record<string, ModelInfo> = {}
 
-	const response = await axios.get(url, { headers })
+	const axiosInstance = createConfiguredAxiosInstance()
+	const response = await axiosInstance.get(url, { headers })
 	const parsed = DeepInfraModelsResponseSchema.safeParse(response.data)
 	const data = parsed.success ? parsed.data.data : response.data?.data || []
 

--- a/src/api/providers/fetchers/glama.ts
+++ b/src/api/providers/fetchers/glama.ts
@@ -1,14 +1,14 @@
-import axios from "axios"
-
 import type { ModelInfo } from "@roo-code/types"
 
 import { parseApiPrice } from "../../../shared/cost"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 export async function getGlamaModels(): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
 
 	try {
-		const response = await axios.get("https://glama.ai/api/gateway/v1/models")
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get("https://glama.ai/api/gateway/v1/models")
 		const rawModels = response.data
 
 		for (const rawModel of rawModels) {

--- a/src/api/providers/fetchers/huggingface.ts
+++ b/src/api/providers/fetchers/huggingface.ts
@@ -1,6 +1,6 @@
-import axios from "axios"
 import { z } from "zod"
 import type { ModelInfo } from "@roo-code/types"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 import {
 	HUGGINGFACE_API_URL,
 	HUGGINGFACE_CACHE_DURATION,
@@ -133,7 +133,8 @@ export async function getHuggingFaceModels(): Promise<ModelRecord> {
 	const models: ModelRecord = {}
 
 	try {
-		const response = await axios.get<HuggingFaceApiResponse>(HUGGINGFACE_API_URL, {
+		const axiosInstance = createConfiguredAxiosInstance({ timeout: 10000 })
+		const response = await axiosInstance.get<HuggingFaceApiResponse>(HUGGINGFACE_API_URL, {
 			headers: {
 				"Upgrade-Insecure-Requests": "1",
 				"Sec-Fetch-Dest": "document",
@@ -144,7 +145,6 @@ export async function getHuggingFaceModels(): Promise<ModelRecord> {
 				Pragma: "no-cache",
 				"Cache-Control": "no-cache",
 			},
-			timeout: 10000, // 10 second timeout
 		})
 
 		const result = huggingFaceApiResponseSchema.safeParse(response.data)
@@ -189,7 +189,7 @@ export async function getHuggingFaceModels(): Promise<ModelRecord> {
 		}
 
 		// Re-throw with more context
-		if (axios.isAxiosError(error)) {
+		if (error && typeof error === "object" && "isAxiosError" in error && error.isAxiosError) {
 			if (error.response) {
 				throw new Error(
 					`Failed to fetch HuggingFace models: ${error.response.status} ${error.response.statusText}`,
@@ -258,7 +258,8 @@ export async function getHuggingFaceModelsWithMetadata(): Promise<HuggingFaceMod
 		}
 
 		// If no cached raw models, fetch directly from API
-		const response = await axios.get(HUGGINGFACE_API_URL, {
+		const axiosInstance = createConfiguredAxiosInstance({ timeout: 10000 })
+		const response = await axiosInstance.get(HUGGINGFACE_API_URL, {
 			headers: {
 				"Upgrade-Insecure-Requests": "1",
 				"Sec-Fetch-Dest": "document",
@@ -269,7 +270,6 @@ export async function getHuggingFaceModelsWithMetadata(): Promise<HuggingFaceMod
 				Pragma: "no-cache",
 				"Cache-Control": "no-cache",
 			},
-			timeout: 10000,
 		})
 
 		const models = response.data?.data || []

--- a/src/api/providers/fetchers/io-intelligence.ts
+++ b/src/api/providers/fetchers/io-intelligence.ts
@@ -1,8 +1,8 @@
-import axios from "axios"
 import { z } from "zod"
 import type { ModelInfo } from "@roo-code/types"
 import { IO_INTELLIGENCE_CACHE_DURATION } from "@roo-code/types"
 import type { ModelRecord } from "../../../shared/api"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 /**
  * IO Intelligence Model Schema
@@ -121,11 +121,11 @@ export async function getIOIntelligenceModels(apiKey?: string): Promise<ModelRec
 			throw new Error("IO Intelligence API key is required")
 		}
 
-		const response = await axios.get<IOIntelligenceApiResponse>(
+		const axiosInstance = createConfiguredAxiosInstance({ timeout: 10000 })
+		const response = await axiosInstance.get<IOIntelligenceApiResponse>(
 			"https://api.intelligence.io.solutions/api/v1/models",
 			{
 				headers,
-				timeout: 10000, // 10 second timeout
 			},
 		)
 
@@ -156,7 +156,7 @@ export async function getIOIntelligenceModels(apiKey?: string): Promise<ModelRec
 		}
 
 		// Re-throw with more context
-		if (axios.isAxiosError(error)) {
+		if (error && typeof error === "object" && "isAxiosError" in error && error.isAxiosError) {
 			if (error.response) {
 				throw new Error(
 					`Failed to fetch IO Intelligence models: ${error.response.status} ${error.response.statusText}`,

--- a/src/api/providers/fetchers/litellm.ts
+++ b/src/api/providers/fetchers/litellm.ts
@@ -1,8 +1,7 @@
-import axios from "axios"
-
 import { LITELLM_COMPUTER_USE_MODELS } from "@roo-code/types"
 
 import type { ModelRecord } from "../../../shared/api"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 import { DEFAULT_HEADERS } from "../constants"
 /**
@@ -29,8 +28,9 @@ export async function getLiteLLMModels(apiKey: string, baseUrl: string): Promise
 		// Normalize the pathname by removing trailing slashes and multiple slashes
 		urlObj.pathname = urlObj.pathname.replace(/\/+$/, "").replace(/\/+/g, "/") + "/v1/model/info"
 		const url = urlObj.href
-		// Added timeout to prevent indefinite hanging
-		const response = await axios.get(url, { headers, timeout: 5000 })
+		// Create configured axios instance with proxy and CA support
+		const axiosInstance = createConfiguredAxiosInstance({ timeout: 5000 })
+		const response = await axiosInstance.get(url, { headers })
 		const models: ModelRecord = {}
 
 		const computerModels = Array.from(LITELLM_COMPUTER_USE_MODELS)
@@ -84,16 +84,18 @@ export async function getLiteLLMModels(apiKey: string, baseUrl: string): Promise
 		return models
 	} catch (error: any) {
 		console.error("Error fetching LiteLLM models:", error.message ? error.message : error)
-		if (axios.isAxiosError(error) && error.response) {
-			throw new Error(
-				`Failed to fetch LiteLLM models: ${error.response.status} ${error.response.statusText}. Check base URL and API key.`,
-			)
-		} else if (axios.isAxiosError(error) && error.request) {
-			throw new Error(
-				"Failed to fetch LiteLLM models: No response from server. Check LiteLLM server status and base URL.",
-			)
-		} else {
-			throw new Error(`Failed to fetch LiteLLM models: ${error.message || "An unknown error occurred."}`)
+		// Check if it's an axios error to provide more specific error messages
+		if (error && typeof error === "object" && "isAxiosError" in error && error.isAxiosError) {
+			if (error.response) {
+				throw new Error(
+					`Failed to fetch LiteLLM models: ${error.response.status} ${error.response.statusText}. Check base URL and API key.`,
+				)
+			} else if (error.request) {
+				throw new Error(
+					"Failed to fetch LiteLLM models: No response from server. Check LiteLLM server status and base URL.",
+				)
+			}
 		}
+		throw new Error(`Failed to fetch LiteLLM models: ${error.message || "An unknown error occurred."}`)
 	}
 }

--- a/src/api/providers/fetchers/lmstudio.ts
+++ b/src/api/providers/fetchers/lmstudio.ts
@@ -1,7 +1,7 @@
 import { ModelInfo, lMStudioDefaultModelInfo } from "@roo-code/types"
 import { LLM, LLMInfo, LLMInstanceInfo, LMStudioClient } from "@lmstudio/sdk"
-import axios from "axios"
 import { flushModels, getModels } from "./modelCache"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 const modelsWithLoadedDetails = new Set<string>()
 
@@ -13,7 +13,8 @@ export const forceFullModelDetailsLoad = async (baseUrl: string, modelId: string
 	try {
 		// test the connection to LM Studio first
 		// errors will be caught further down
-		await axios.get(`${baseUrl}/v1/models`)
+		const axiosInstance = createConfiguredAxiosInstance()
+		await axiosInstance.get(`${baseUrl}/v1/models`)
 		const lmsUrl = baseUrl.replace(/^http:\/\//, "ws://").replace(/^https:\/\//, "wss://")
 
 		const client = new LMStudioClient({ baseUrl: lmsUrl })
@@ -67,7 +68,8 @@ export async function getLMStudioModels(baseUrl = "http://localhost:1234"): Prom
 
 		// test the connection to LM Studio first
 		// errors will be caught further down
-		await axios.get(`${baseUrl}/v1/models`)
+		const axiosInstance2 = createConfiguredAxiosInstance()
+		await axiosInstance2.get(`${baseUrl}/v1/models`)
 
 		const client = new LMStudioClient({ baseUrl: lmsUrl })
 

--- a/src/api/providers/fetchers/ollama.ts
+++ b/src/api/providers/fetchers/ollama.ts
@@ -1,6 +1,6 @@
-import axios from "axios"
 import { ModelInfo, ollamaDefaultModelInfo } from "@roo-code/types"
 import { z } from "zod"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 const OllamaModelDetailsSchema = z.object({
 	family: z.string(),
@@ -74,14 +74,15 @@ export async function getOllamaModels(
 			headers["Authorization"] = `Bearer ${apiKey}`
 		}
 
-		const response = await axios.get<OllamaModelsResponse>(`${baseUrl}/api/tags`, { headers })
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get<OllamaModelsResponse>(`${baseUrl}/api/tags`, { headers })
 		const parsedResponse = OllamaModelsResponseSchema.safeParse(response.data)
 		let modelInfoPromises = []
 
 		if (parsedResponse.success) {
 			for (const ollamaModel of parsedResponse.data.models) {
 				modelInfoPromises.push(
-					axios
+					axiosInstance
 						.post<OllamaModelInfoResponse>(
 							`${baseUrl}/api/show`,
 							{

--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -1,4 +1,3 @@
-import axios from "axios"
 import { z } from "zod"
 
 import {
@@ -12,6 +11,7 @@ import {
 
 import type { ApiHandlerOptions } from "../../../shared/api"
 import { parseApiPrice } from "../../../shared/cost"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 /**
  * OpenRouterBaseModel
@@ -100,7 +100,8 @@ export async function getOpenRouterModels(options?: ApiHandlerOptions): Promise<
 	const baseURL = options?.openRouterBaseUrl || "https://openrouter.ai/api/v1"
 
 	try {
-		const response = await axios.get<OpenRouterModelsResponse>(`${baseURL}/models`)
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get<OpenRouterModelsResponse>(`${baseURL}/models`)
 		const result = openRouterModelsResponseSchema.safeParse(response.data)
 		const data = result.success ? result.data.data : response.data.data
 
@@ -146,7 +147,10 @@ export async function getOpenRouterModelEndpoints(
 	const baseURL = options?.openRouterBaseUrl || "https://openrouter.ai/api/v1"
 
 	try {
-		const response = await axios.get<OpenRouterModelEndpointsResponse>(`${baseURL}/models/${modelId}/endpoints`)
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get<OpenRouterModelEndpointsResponse>(
+			`${baseURL}/models/${modelId}/endpoints`,
+		)
 		const result = openRouterModelEndpointsResponseSchema.safeParse(response.data)
 		const data = result.success ? result.data.data : response.data.data
 

--- a/src/api/providers/fetchers/requesty.ts
+++ b/src/api/providers/fetchers/requesty.ts
@@ -1,9 +1,8 @@
-import axios from "axios"
-
 import type { ModelInfo } from "@roo-code/types"
 
 import { parseApiPrice } from "../../../shared/cost"
 import { toRequestyServiceUrl } from "../../../shared/utils/requesty"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 export async function getRequestyModels(baseUrl?: string, apiKey?: string): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
@@ -18,7 +17,8 @@ export async function getRequestyModels(baseUrl?: string, apiKey?: string): Prom
 		const resolvedBaseUrl = toRequestyServiceUrl(baseUrl)
 		const modelsUrl = new URL("v1/models", resolvedBaseUrl)
 
-		const response = await axios.get(modelsUrl.toString(), { headers })
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get(modelsUrl.toString(), { headers })
 		const rawModels = response.data.data
 
 		for (const rawModel of rawModels) {

--- a/src/api/providers/fetchers/unbound.ts
+++ b/src/api/providers/fetchers/unbound.ts
@@ -1,6 +1,5 @@
-import axios from "axios"
-
 import type { ModelInfo } from "@roo-code/types"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 export async function getUnboundModels(apiKey?: string | null): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
@@ -12,7 +11,8 @@ export async function getUnboundModels(apiKey?: string | null): Promise<Record<s
 			headers["Authorization"] = `Bearer ${apiKey}`
 		}
 
-		const response = await axios.get("https://api.getunbound.ai/models", { headers })
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get("https://api.getunbound.ai/models", { headers })
 
 		if (response.data) {
 			const rawModels: Record<string, any> = response.data

--- a/src/api/providers/fetchers/vercel-ai-gateway.ts
+++ b/src/api/providers/fetchers/vercel-ai-gateway.ts
@@ -1,4 +1,3 @@
-import axios from "axios"
 import { z } from "zod"
 
 import type { ModelInfo } from "@roo-code/types"
@@ -6,6 +5,7 @@ import { VERCEL_AI_GATEWAY_VISION_ONLY_MODELS, VERCEL_AI_GATEWAY_VISION_AND_TOOL
 
 import type { ApiHandlerOptions } from "../../../shared/api"
 import { parseApiPrice } from "../../../shared/cost"
+import { createConfiguredAxiosInstance } from "../../../utils/httpClient"
 
 /**
  * VercelAiGatewayPricing
@@ -57,7 +57,8 @@ export async function getVercelAiGatewayModels(options?: ApiHandlerOptions): Pro
 	const baseURL = "https://ai-gateway.vercel.sh/v1"
 
 	try {
-		const response = await axios.get<VercelAiGatewayModelsResponse>(`${baseURL}/models`)
+		const axiosInstance = createConfiguredAxiosInstance()
+		const response = await axiosInstance.get<VercelAiGatewayModelsResponse>(`${baseURL}/models`)
 		const result = vercelAiGatewayModelsResponseSchema.safeParse(response.data)
 		const data = result.success ? result.data.data : response.data.data
 

--- a/src/services/browser/browserDiscovery.ts
+++ b/src/services/browser/browserDiscovery.ts
@@ -1,6 +1,6 @@
 import * as net from "net"
-import axios from "axios"
 import * as dns from "dns"
+import { createConfiguredAxiosInstance } from "../../utils/httpClient"
 
 /**
  * Check if a port is open on a given host
@@ -45,7 +45,8 @@ export async function isPortOpen(host: string, port: number, timeout = 1000): Pr
 export async function tryChromeHostUrl(chromeHostUrl: string): Promise<boolean> {
 	try {
 		console.log(`Trying to connect to Chrome at: ${chromeHostUrl}/json/version`)
-		await axios.get(`${chromeHostUrl}/json/version`, { timeout: 1000 })
+		const axiosInstance = createConfiguredAxiosInstance({ timeout: 1000 })
+		await axiosInstance.get(`${chromeHostUrl}/json/version`)
 		return true
 	} catch (error) {
 		return false

--- a/src/services/marketplace/RemoteConfigLoader.ts
+++ b/src/services/marketplace/RemoteConfigLoader.ts
@@ -1,4 +1,3 @@
-import axios from "axios"
 import * as yaml from "yaml"
 import { z } from "zod"
 
@@ -9,6 +8,7 @@ import {
 	mcpMarketplaceItemSchema,
 } from "@roo-code/types"
 import { getRooCodeApiUrl } from "@roo-code/cloud"
+import { createConfiguredAxiosInstance } from "../../utils/httpClient"
 
 const modeMarketplaceResponse = z.object({
 	items: z.array(modeMarketplaceItemSchema),
@@ -88,8 +88,8 @@ export class RemoteConfigLoader {
 
 		for (let i = 0; i < maxRetries; i++) {
 			try {
-				const response = await axios.get(url, {
-					timeout: 10000, // 10 second timeout
+				const axiosInstance = createConfiguredAxiosInstance({ timeout: 10000 })
+				const response = await axiosInstance.get(url, {
 					headers: {
 						Accept: "application/json",
 						"Content-Type": "application/json",

--- a/src/utils/__tests__/httpClient.spec.ts
+++ b/src/utils/__tests__/httpClient.spec.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import * as fs from "fs"
+import { createConfiguredAxiosInstance, getConfiguredAxiosConfig, clearCertificateCache } from "../httpClient"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	workspace: {
+		getConfiguration: vi.fn(),
+	},
+}))
+
+// Mock fs
+vi.mock("fs", () => ({
+	readFileSync: vi.fn(),
+}))
+
+// Mock proxy-agent
+vi.mock("proxy-agent", () => ({
+	ProxyAgent: vi.fn().mockImplementation(() => ({
+		// Mock proxy agent implementation
+	})),
+}))
+
+describe("httpClient", () => {
+	const mockGetConfiguration = vi.mocked(vscode.workspace.getConfiguration)
+	const mockReadFileSync = vi.mocked(fs.readFileSync)
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Clear environment variables
+		delete process.env.HTTPS_PROXY
+		delete process.env.https_proxy
+		delete process.env.HTTP_PROXY
+		delete process.env.http_proxy
+		delete process.env.ALL_PROXY
+		delete process.env.all_proxy
+		delete process.env.NODE_EXTRA_CA_CERTS
+		delete process.env.AWS_CA_BUNDLE
+		// Clear the certificate cache
+		clearCertificateCache()
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe("createConfiguredAxiosInstance", () => {
+		it("should create axios instance with default configuration when no proxy is configured", () => {
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockGetConfiguration).toHaveBeenCalledWith("http")
+		})
+
+		it("should create axios instance with proxy configuration when VS Code proxy is set", () => {
+			// Mock VS Code configuration with proxy
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return "http://proxy.example.com:8080"
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockGetConfiguration).toHaveBeenCalledWith("http")
+		})
+
+		it("should create axios instance with proxy configuration when environment proxy is set", () => {
+			// Set environment proxy
+			process.env.HTTPS_PROXY = "http://proxy.example.com:8080"
+
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockGetConfiguration).toHaveBeenCalledWith("http")
+		})
+
+		it("should handle custom CA certificates", () => {
+			const mockCaContent = Buffer.from("mock-ca-content")
+			const caPath = "/path/to/ca.crt"
+
+			// Set CA environment variable
+			process.env.NODE_EXTRA_CA_CERTS = caPath
+
+			// Mock file reading
+			mockReadFileSync.mockReturnValue(mockCaContent)
+
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockReadFileSync).toHaveBeenCalledWith(caPath)
+		})
+
+		it("should handle CA certificate reading errors gracefully", () => {
+			const caPath = "/path/to/nonexistent/ca.crt"
+
+			// Set CA environment variable
+			process.env.NODE_EXTRA_CA_CERTS = caPath
+
+			// Mock file reading error
+			mockReadFileSync.mockImplementation(() => {
+				throw new Error("File not found")
+			})
+
+			// Mock console.warn to avoid test output
+			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockReadFileSync).toHaveBeenCalledWith(caPath)
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to read custom CA bundle; continuing without it",
+				expect.objectContaining({
+					error: "File not found",
+					caPath,
+				}),
+			)
+
+			consoleSpy.mockRestore()
+		})
+
+		it("should merge provided configuration with proxy/CA configuration", () => {
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const customConfig = {
+				timeout: 5000,
+				headers: {
+					"Custom-Header": "value",
+				},
+			}
+
+			const axiosInstance = createConfiguredAxiosInstance(customConfig)
+
+			expect(axiosInstance).toBeDefined()
+			// The axios instance should have the custom configuration merged
+			expect(axiosInstance.defaults.timeout).toBe(5000)
+			expect(axiosInstance.defaults.headers["Custom-Header"]).toBe("value")
+		})
+
+		it("should handle configuration errors gracefully and fall back to default axios", () => {
+			// Mock VS Code configuration to throw an error
+			mockGetConfiguration.mockImplementation(() => {
+				throw new Error("Configuration error")
+			})
+
+			// Mock console.warn to avoid test output
+			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to create configured axios instance; falling back to default axios",
+				expect.objectContaining({
+					error: "Configuration error",
+				}),
+			)
+
+			consoleSpy.mockRestore()
+		})
+
+		it("should prefer AWS_CA_BUNDLE over NODE_EXTRA_CA_CERTS", () => {
+			const mockCaContent = Buffer.from("mock-ca-content")
+			const awsCaPath = "/path/to/aws-ca.crt"
+			const nodeCaPath = "/path/to/node-ca.crt"
+
+			// Set both CA environment variables
+			process.env.NODE_EXTRA_CA_CERTS = nodeCaPath
+			process.env.AWS_CA_BUNDLE = awsCaPath
+
+			// Mock file reading
+			mockReadFileSync.mockReturnValue(mockCaContent)
+
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			// Should use AWS_CA_BUNDLE path, not NODE_EXTRA_CA_CERTS
+			expect(mockReadFileSync).toHaveBeenCalledWith(awsCaPath)
+			expect(mockReadFileSync).not.toHaveBeenCalledWith(nodeCaPath)
+		})
+
+		it("should handle proxyStrictSSL configuration", () => {
+			// Mock VS Code configuration with proxyStrictSSL disabled
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return "http://proxy.example.com:8080"
+					if (key === "proxyStrictSSL") return false
+					return undefined
+				}),
+			} as any)
+
+			const axiosInstance = createConfiguredAxiosInstance()
+
+			expect(axiosInstance).toBeDefined()
+			expect(mockGetConfiguration).toHaveBeenCalledWith("http")
+		})
+	})
+
+	describe("getConfiguredAxiosConfig", () => {
+		it("should return configuration object with proxy and CA settings", () => {
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const config = getConfiguredAxiosConfig()
+
+			expect(config).toBeDefined()
+			expect(typeof config).toBe("object")
+		})
+
+		it("should merge provided configuration with proxy/CA settings", () => {
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			const customConfig = {
+				timeout: 5000,
+				headers: {
+					"Custom-Header": "value",
+				},
+			}
+
+			const config = getConfiguredAxiosConfig(customConfig)
+
+			expect(config).toBeDefined()
+			expect(config.timeout).toBe(5000)
+			expect(config.headers).toEqual({ "Custom-Header": "value" })
+		})
+
+		it("should handle configuration errors gracefully", () => {
+			// Mock VS Code configuration to throw an error
+			mockGetConfiguration.mockImplementation(() => {
+				throw new Error("Configuration error")
+			})
+
+			// Mock console.warn to avoid test output
+			const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+			const config = getConfiguredAxiosConfig()
+
+			expect(config).toEqual({})
+			expect(consoleSpy).toHaveBeenCalledWith(
+				"Failed to create configured axios config; falling back to provided config",
+				expect.objectContaining({
+					error: "Configuration error",
+				}),
+			)
+
+			consoleSpy.mockRestore()
+		})
+	})
+
+	describe("CA certificate caching", () => {
+		it("should cache CA certificates to avoid repeated file reads", () => {
+			const mockCaContent = Buffer.from("mock-ca-content")
+			const caPath = "/path/to/ca.crt"
+
+			// Set CA environment variable
+			process.env.NODE_EXTRA_CA_CERTS = caPath
+
+			// Mock file reading
+			mockReadFileSync.mockReturnValue(mockCaContent)
+
+			// Mock VS Code configuration
+			mockGetConfiguration.mockReturnValue({
+				get: vi.fn((key: string) => {
+					if (key === "proxy") return ""
+					if (key === "proxyStrictSSL") return true
+					return undefined
+				}),
+			} as any)
+
+			// Create multiple instances
+			const axiosInstance1 = createConfiguredAxiosInstance()
+			const axiosInstance2 = createConfiguredAxiosInstance()
+
+			expect(axiosInstance1).toBeDefined()
+			expect(axiosInstance2).toBeDefined()
+
+			// File should only be read once due to caching
+			expect(mockReadFileSync).toHaveBeenCalledTimes(1)
+			expect(mockReadFileSync).toHaveBeenCalledWith(caPath)
+		})
+	})
+})

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -1,0 +1,207 @@
+import * as vscode from "vscode"
+import * as fs from "fs"
+import * as https from "https"
+import * as http from "http"
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios"
+import { ProxyAgent } from "proxy-agent"
+
+/**
+ * Configuration for proxy settings
+ */
+interface ProxyConfig {
+	isProxyConfigured: boolean
+}
+
+/**
+ * Configuration for TLS settings
+ */
+interface TLSConfig {
+	strictSSL: boolean
+	ca?: Buffer
+}
+
+/**
+ * HTTP agent configuration
+ */
+interface HTTPAgents {
+	httpAgent?: http.Agent
+	httpsAgent?: https.Agent
+}
+
+/**
+ * Cache for loaded CA certificates to avoid repeated I/O operations
+ */
+const cachedCertificates = new Map<string, Buffer>()
+
+/**
+ * Get proxy configuration from VS Code settings and environment variables.
+ * Note: We only check if a proxy is configured; proxy-agent handles URL detection.
+ */
+function getProxyConfiguration(): ProxyConfig {
+	const httpConfig = vscode.workspace.getConfiguration("http")
+	const vscodeProxy = (httpConfig.get<string>("proxy") || "").trim()
+
+	// Check if any proxy configuration exists (VS Code or environment variables)
+	const hasProxyConfig = !!(
+		vscodeProxy ||
+		process.env.HTTPS_PROXY ||
+		process.env.https_proxy ||
+		process.env.HTTP_PROXY ||
+		process.env.http_proxy ||
+		process.env.ALL_PROXY ||
+		process.env.all_proxy
+	)
+
+	return { isProxyConfigured: hasProxyConfig }
+}
+
+/**
+ * Get TLS configuration including SSL validation and CA certificates.
+ */
+function getTLSConfiguration(): TLSConfig {
+	const httpConfig = vscode.workspace.getConfiguration("http")
+	const strictSSL = httpConfig.get<boolean>("proxyStrictSSL", true)
+
+	const caPath = (process.env.AWS_CA_BUNDLE || process.env.NODE_EXTRA_CA_CERTS || "").trim()
+	const ca = caPath ? loadCACertificate(caPath) : undefined
+
+	return { strictSSL, ca }
+}
+
+/**
+ * Load CA certificate from file system with caching to avoid repeated I/O operations.
+ */
+function loadCACertificate(caPath: string): Buffer | undefined {
+	if (!caPath) return undefined
+
+	// Check cache first
+	if (cachedCertificates.has(caPath)) {
+		return cachedCertificates.get(caPath)
+	}
+
+	try {
+		const ca = fs.readFileSync(caPath)
+		cachedCertificates.set(caPath, ca)
+		return ca
+	} catch (e) {
+		console.warn("Failed to read custom CA bundle; continuing without it", {
+			error: e instanceof Error ? e.message : String(e),
+			caPath,
+		})
+		return undefined
+	}
+}
+
+/**
+ * Create HTTP/HTTPS agents with proxy and TLS configuration.
+ * ProxyAgent automatically detects proxy URLs from environment variables.
+ */
+function createHTTPAgents(proxyConfig: ProxyConfig, tlsConfig: TLSConfig): HTTPAgents {
+	const agentOptions: https.AgentOptions = {
+		rejectUnauthorized: tlsConfig.strictSSL,
+		...(tlsConfig.ca ? { ca: tlsConfig.ca } : {}),
+	}
+
+	if (proxyConfig.isProxyConfigured) {
+		// ProxyAgent automatically detects proxy URLs from environment variables
+		// We pass TLS configuration through the httpsAgent option
+		const proxyAgent = new ProxyAgent({
+			httpsAgent: new https.Agent(agentOptions),
+			rejectUnauthorized: tlsConfig.strictSSL,
+			...(tlsConfig.ca ? { ca: tlsConfig.ca } : {}),
+		})
+
+		return {
+			httpAgent: proxyAgent,
+			httpsAgent: proxyAgent,
+		}
+	}
+
+	// Direct connection without proxy
+	return {
+		httpsAgent: new https.Agent(agentOptions),
+	}
+}
+
+/**
+ * Creates an axios instance configured with VS Code's proxy settings and custom Certificate Authorities (CAs).
+ *
+ * This function centralizes the configuration of HTTP clients to ensure consistent application
+ * of proxy settings and custom CAs across the codebase. It respects VS Code's HTTP configuration
+ * and environment variables for proxy settings.
+ *
+ * Environment Variables (automatically detected by proxy-agent):
+ * - `HTTPS_PROXY` / `https_proxy`: HTTPS proxy server URL
+ * - `HTTP_PROXY` / `http_proxy`: HTTP proxy server URL
+ * - `ALL_PROXY` / `all_proxy`: Fallback proxy for all protocols
+ * - `NO_PROXY` / `no_proxy`: Comma-separated list of hosts to bypass proxy
+ * - `NODE_EXTRA_CA_CERTS`: Path to additional CA certificates file
+ * - `AWS_CA_BUNDLE`: Path to AWS-specific CA bundle (takes precedence over NODE_EXTRA_CA_CERTS)
+ *
+ * VS Code Settings:
+ * - `http.proxy`: Proxy URL configured in VS Code
+ * - `http.proxyStrictSSL`: Whether to use strict SSL validation for proxy connections
+ *
+ * @param config Optional axios configuration to merge with the proxy/CA configuration
+ * @returns Configured axios instance with proxy and CA support
+ */
+export function createConfiguredAxiosInstance(config?: AxiosRequestConfig): AxiosInstance {
+	try {
+		const proxyConfig = getProxyConfiguration()
+		const tlsConfig = getTLSConfiguration()
+		const agents = createHTTPAgents(proxyConfig, tlsConfig)
+
+		const axiosConfig: AxiosRequestConfig = {
+			...config,
+			...agents,
+		}
+
+		return axios.create(axiosConfig)
+	} catch (err) {
+		console.warn("Failed to create configured axios instance; falling back to default axios", {
+			error: err instanceof Error ? err.message : String(err),
+		})
+		// Fall back to default axios instance with provided config
+		return config ? axios.create(config) : axios.create()
+	}
+}
+
+/**
+ * Creates an axios request configuration object with proxy and CA settings applied.
+ * This is useful when you need to pass configuration to existing axios instances
+ * rather than creating a new instance.
+ *
+ * @param config Optional base configuration to merge with proxy/CA settings
+ * @returns Axios request configuration with proxy and CA support
+ */
+export function getConfiguredAxiosConfig(config?: AxiosRequestConfig): AxiosRequestConfig {
+	try {
+		const proxyConfig = getProxyConfiguration()
+		const tlsConfig = getTLSConfiguration()
+		const agents = createHTTPAgents(proxyConfig, tlsConfig)
+
+		return {
+			...config,
+			...agents,
+		}
+	} catch (err) {
+		console.warn("Failed to create configured axios config; falling back to provided config", {
+			error: err instanceof Error ? err.message : String(err),
+		})
+		return config || {}
+	}
+}
+
+/**
+ * Clears the CA certificate cache. This is primarily used for testing.
+ * @internal
+ */
+export function clearCertificateCache(): void {
+	cachedCertificates.clear()
+}
+
+/**
+ * Legacy function for backward compatibility.
+ * @deprecated Use createConfiguredAxiosInstance instead
+ */
+export const createHttpClient = createConfiguredAxiosInstance


### PR DESCRIPTION
### Related GitHub Issue

Closes: # <!-- Replace with the issue number, e.g., Closes: #123 -->
This PR implements the centralized HTTP client method discussed in the comments of #7081.

### Roo Code Task Context (Optional)

### Description

This PR introduces a centralized HTTP client utility to consistently handle proxy settings and custom Certificate Authorities (CAs) across the Roo Code extension. This addresses the need for robust proxy and CA support, especially in corporate environments.

**Key changes include:**

-   **New Utility (`src/utils/httpClient.ts`):**
    -   `createConfiguredAxiosInstance()`: Creates an Axios instance with integrated proxy and CA logic.
    -   `getConfiguredAxiosConfig()`: Returns an Axios configuration object for existing instances.
    -   Supports VS Code's `http.proxy` and `http.proxyStrictSSL` settings.
    -   Respects standard environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, `NO_PROXY`).
    -   Handles custom CA certificates via `AWS_CA_BUNDLE` (with precedence) and `NODE_EXTRA_CA_CERTS`.
    -   Includes CA certificate caching for performance.
-   **Migration of HTTP Clients:** All relevant API fetchers (e.g., LiteLLM, OpenRouter, Ollama, HuggingFace, DeepInfra, etc.) and services (e.g., `RemoteConfigLoader`, `browserDiscovery`) have been updated to use this new centralized utility, replacing direct `axios` imports.

Reviewers should focus on the implementation of `src/utils/httpClient.ts` to ensure the proxy and CA logic is correctly applied and that all migrations to the new utility are complete and functional.

### Test Procedure

1.  **Unit Tests:** Run `npm test src/utils/__tests__/httpClient.spec.ts` to verify the core logic of the HTTP client utility, including proxy detection, CA loading, caching, and error handling. (All 13 tests should pass).
2.  **Manual Testing (Proxy):**
    *   Configure VS Code's `http.proxy` setting or set `HTTPS_PROXY`/`HTTP_PROXY` environment variables to point to a test proxy.
    *   Verify that API calls (e.g., fetching models from various providers) correctly route through the configured proxy.
    *   Test with `http.proxyStrictSSL` enabled and disabled to ensure SSL validation behaves as expected.
3.  **Manual Testing (Custom CA):**
    *   Set `AWS_CA_BUNDLE` or `NODE_EXTRA_CA_CERTS` environment variables to a path containing a custom CA certificate.
    *   Ensure that API calls to services using self-signed certificates (if applicable in a test environment) are successful.
4.  **Linting and Type Checks:** Run `npm run lint` and `npm run typecheck` to ensure no new errors are introduced.

### Pre-Submission Checklist

-   [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
-   [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
-   [ ] **Self-Review**: I have performed a thorough self-review of my code.
-   [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
-   [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
-   [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A (Backend utility changes)

### Documentation Updates

-   [ ] No documentation updates are required.
-   [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

All linting, type checks, and unit tests (13/13) are passing. The implementation ensures that all external HTTP requests made by the extension will now consistently respect user-configured proxy and CA settings.

### Get in Touch

<!-- Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR -->

---
<a href="https://cursor.com/background-agent?bcId=bc-bb988e5b-a4a5-4078-99ba-1f6d690ba320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb988e5b-a4a5-4078-99ba-1f6d690ba320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

